### PR TITLE
Provide SSH keys as flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,17 @@
 {
   "nodes": {
+    "alexanderwallau-keys": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-bNc+52p9foYILK0S4BGYPwnTMXzCv2QU8ThT5NWBZzo=",
+        "type": "file",
+        "url": "https://github.com/alexanderwallau.keys"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://github.com/alexanderwallau.keys"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -69,6 +81,7 @@
     },
     "root": {
       "inputs": {
+        "alexanderwallau-keys": "alexanderwallau-keys",
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
         "nixos-hardware": "nixos-hardware",

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,10 @@
   description = "A very basic flake";
 
   inputs = {
+    # we are using the alexanderwallau-keys flake to get the ssh keys from github
+    alexanderwallau-keys.url = "https://github.com/alexanderwallau.keys";
+    alexanderwallau-keys.flake = false;
+
     # https://github.com/nixos/nixpkgs
     # nixos repository
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/user/awallau.nix
+++ b/user/awallau.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, config, ... }:
+{ lib, pkgs, config, alexanderwallau-keys, ... }:
 with lib;
 let cfg = config.awallau.user.awallau;
 in
@@ -13,12 +13,7 @@ in
       home = "/home/awallau";
       extraGroups = [ "wheel" ];
       shell = pkgs.zsh;
-      openssh.authorizedKeys.keyFiles = [
-        (pkgs.fetchurl {
-          url = "https://github.com/alexanderwallau.keys";
-          hash = "sha256-pFc699BTaSaVOrTNSJ1G/1dl8uSkooi91vXmyBdb9og=";
-        })
-      ];
+      openssh.authorizedKeys.keyFiles = [ alexanderwallau-keys ];
     };
     users.extraUsers.awallau.extraGroups = mkIf config.virtualisation.docker.enable [ "docker" ];
     nix.settings.allowed-users = [ "awallau" ];

--- a/user/root.nix
+++ b/user/root.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, config, ... }:
+{ lib, pkgs, config, alexanderwallau-keys, ... }:
 with lib;
 let cfg = config.awallau.user.awallau;
 in
@@ -9,12 +9,7 @@ in
   config = mkIf cfg.enable {
 
     users.users.root = {
-      openssh.authorizedKeys.keyFiles = [
-        (pkgs.fetchurl {
-          url = "https://github.com/alexanderwallau.keys";
-          hash = "sha256-pFc699BTaSaVOrTNSJ1G/1dl8uSkooi91vXmyBdb9og=";
-        })
-      ];
+      openssh.authorizedKeys.keyFiles = [ alexanderwallau-keys ];
     };
     nix.settings.allowed-users = [ "root" ];
   };


### PR DESCRIPTION
-> pulls `https://github.com/alexanderwallau.keys` as a flake input
-> hashes are stored in flake.lock
-> `nix flake update` or `nix flake lock --update-input alexanderwallau-keys` would update the input